### PR TITLE
Add parameter hints for Pine Script functions

### DIFF
--- a/src/main/java/io/github/houseofai/pinescript/parameterinfo/PineScriptFunctionRepository.java
+++ b/src/main/java/io/github/houseofai/pinescript/parameterinfo/PineScriptFunctionRepository.java
@@ -1,0 +1,356 @@
+package io.github.houseofai.pinescript.parameterinfo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.github.houseofai.pinescript.parameterinfo.PineScriptFunctionSignature.Parameter;
+
+/**
+ * Repository of Pine Script function signatures.
+ */
+public class PineScriptFunctionRepository {
+    private static final Map<String, PineScriptFunctionSignature> SIGNATURES = new HashMap<>();
+
+    static {
+        // Plot functions
+        SIGNATURES.put("plot", new PineScriptFunctionSignature("plot",
+                new Parameter("series", "series"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("color", "color", "color.blue"),
+                new Parameter("linewidth", "int", "1"),
+                new Parameter("style", "plot_style", "plot.style_line"),
+                new Parameter("trackprice", "bool", "false"),
+                new Parameter("histbase", "float", "0.0"),
+                new Parameter("offset", "int", "0"),
+                new Parameter("join", "bool", "false"),
+                new Parameter("editable", "bool", "true"),
+                new Parameter("show_last", "int", "na"),
+                new Parameter("display", "plot_display", "display.all")
+        ));
+
+        SIGNATURES.put("plotshape", new PineScriptFunctionSignature("plotshape",
+                new Parameter("series", "series"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("style", "string", "shape.xcross"),
+                new Parameter("location", "string", "location.abovebar"),
+                new Parameter("color", "color", "color.red"),
+                new Parameter("offset", "int", "0"),
+                new Parameter("text", "string", "\"\""),
+                new Parameter("textcolor", "color", "color.black"),
+                new Parameter("editable", "bool", "true"),
+                new Parameter("size", "string", "size.auto"),
+                new Parameter("show_last", "int", "na"),
+                new Parameter("display", "plot_display", "display.all")
+        ));
+
+        SIGNATURES.put("plotchar", new PineScriptFunctionSignature("plotchar",
+                new Parameter("series", "series"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("char", "string", "\"\""),
+                new Parameter("location", "string", "location.abovebar"),
+                new Parameter("color", "color", "color.red"),
+                new Parameter("offset", "int", "0"),
+                new Parameter("text", "string", "\"\""),
+                new Parameter("textcolor", "color", "color.black"),
+                new Parameter("editable", "bool", "true"),
+                new Parameter("size", "string", "size.auto"),
+                new Parameter("show_last", "int", "na"),
+                new Parameter("display", "plot_display", "display.all")
+        ));
+
+        SIGNATURES.put("hline", new PineScriptFunctionSignature("hline",
+                new Parameter("price", "float"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("color", "color", "color.black"),
+                new Parameter("linestyle", "hline_style", "hline.style_solid"),
+                new Parameter("linewidth", "int", "1"),
+                new Parameter("editable", "bool", "true"),
+                new Parameter("display", "plot_display", "display.all")
+        ));
+
+        SIGNATURES.put("fill", new PineScriptFunctionSignature("fill",
+                new Parameter("hline1", "hline/plot"),
+                new Parameter("hline2", "hline/plot"),
+                new Parameter("color", "color", "color.blue"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("editable", "bool", "true"),
+                new Parameter("show_last", "int", "na"),
+                new Parameter("fillgaps", "bool", "false")
+        ));
+
+        SIGNATURES.put("bgcolor", new PineScriptFunctionSignature("bgcolor",
+                new Parameter("color", "color"),
+                new Parameter("offset", "int", "0"),
+                new Parameter("editable", "bool", "true"),
+                new Parameter("show_last", "int", "na"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("display", "plot_display", "display.all")
+        ));
+
+        // Technical Analysis functions
+        SIGNATURES.put("ta.sma", new PineScriptFunctionSignature("ta.sma",
+                new Parameter("source", "series"),
+                new Parameter("length", "int")
+        ));
+
+        SIGNATURES.put("ta.ema", new PineScriptFunctionSignature("ta.ema",
+                new Parameter("source", "series"),
+                new Parameter("length", "int")
+        ));
+
+        SIGNATURES.put("ta.rsi", new PineScriptFunctionSignature("ta.rsi",
+                new Parameter("source", "series"),
+                new Parameter("length", "int")
+        ));
+
+        SIGNATURES.put("ta.macd", new PineScriptFunctionSignature("ta.macd",
+                new Parameter("source", "series"),
+                new Parameter("fastlen", "int"),
+                new Parameter("slowlen", "int"),
+                new Parameter("siglen", "int")
+        ));
+
+        SIGNATURES.put("ta.stoch", new PineScriptFunctionSignature("ta.stoch",
+                new Parameter("source", "series"),
+                new Parameter("high", "series"),
+                new Parameter("low", "series"),
+                new Parameter("length", "int")
+        ));
+
+        SIGNATURES.put("ta.bb", new PineScriptFunctionSignature("ta.bb",
+                new Parameter("source", "series"),
+                new Parameter("length", "int"),
+                new Parameter("mult", "float")
+        ));
+
+        SIGNATURES.put("ta.atr", new PineScriptFunctionSignature("ta.atr",
+                new Parameter("length", "int")
+        ));
+
+        SIGNATURES.put("ta.crossover", new PineScriptFunctionSignature("ta.crossover",
+                new Parameter("source1", "series"),
+                new Parameter("source2", "series")
+        ));
+
+        SIGNATURES.put("ta.crossunder", new PineScriptFunctionSignature("ta.crossunder",
+                new Parameter("source1", "series"),
+                new Parameter("source2", "series")
+        ));
+
+        SIGNATURES.put("ta.cross", new PineScriptFunctionSignature("ta.cross",
+                new Parameter("source1", "series"),
+                new Parameter("source2", "series")
+        ));
+
+        // Strategy functions
+        SIGNATURES.put("strategy.entry", new PineScriptFunctionSignature("strategy.entry",
+                new Parameter("id", "string"),
+                new Parameter("direction", "strategy_direction"),
+                new Parameter("qty", "float", "na"),
+                new Parameter("limit", "float", "na"),
+                new Parameter("stop", "float", "na"),
+                new Parameter("oca_name", "string", "\"\""),
+                new Parameter("oca_type", "string", "na"),
+                new Parameter("comment", "string", "\"\""),
+                new Parameter("when", "bool", "true"),
+                new Parameter("alert_message", "string", "na")
+        ));
+
+        SIGNATURES.put("strategy.exit", new PineScriptFunctionSignature("strategy.exit",
+                new Parameter("id", "string"),
+                new Parameter("from_entry", "string", "\"\""),
+                new Parameter("qty", "float", "na"),
+                new Parameter("qty_percent", "float", "na"),
+                new Parameter("profit", "float", "na"),
+                new Parameter("limit", "float", "na"),
+                new Parameter("loss", "float", "na"),
+                new Parameter("stop", "float", "na"),
+                new Parameter("trail_price", "float", "na"),
+                new Parameter("trail_points", "float", "na"),
+                new Parameter("trail_offset", "float", "na"),
+                new Parameter("oca_name", "string", "\"\""),
+                new Parameter("comment", "string", "\"\""),
+                new Parameter("when", "bool", "true"),
+                new Parameter("alert_message", "string", "na")
+        ));
+
+        SIGNATURES.put("strategy.close", new PineScriptFunctionSignature("strategy.close",
+                new Parameter("id", "string"),
+                new Parameter("when", "bool", "true"),
+                new Parameter("comment", "string", "\"\""),
+                new Parameter("qty", "float", "na"),
+                new Parameter("qty_percent", "float", "na"),
+                new Parameter("alert_message", "string", "na")
+        ));
+
+        SIGNATURES.put("strategy.close_all", new PineScriptFunctionSignature("strategy.close_all",
+                new Parameter("when", "bool", "true"),
+                new Parameter("comment", "string", "\"\""),
+                new Parameter("alert_message", "string", "na")
+        ));
+
+        // Request functions
+        SIGNATURES.put("request.security", new PineScriptFunctionSignature("request.security",
+                new Parameter("symbol", "string"),
+                new Parameter("timeframe", "string"),
+                new Parameter("expression", "series"),
+                new Parameter("gaps", "barmerge_gaps", "barmerge.gaps_off"),
+                new Parameter("lookahead", "barmerge_lookahead", "barmerge.lookahead_off"),
+                new Parameter("ignore_invalid_symbol", "bool", "false"),
+                new Parameter("currency", "string", "na")
+        ));
+
+        // Input functions
+        SIGNATURES.put("input.int", new PineScriptFunctionSignature("input.int",
+                new Parameter("defval", "int"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("minval", "int", "na"),
+                new Parameter("maxval", "int", "na"),
+                new Parameter("step", "int", "1"),
+                new Parameter("tooltip", "string", "\"\""),
+                new Parameter("inline", "string", "\"\""),
+                new Parameter("group", "string", "\"\""),
+                new Parameter("confirm", "bool", "false")
+        ));
+
+        SIGNATURES.put("input.float", new PineScriptFunctionSignature("input.float",
+                new Parameter("defval", "float"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("minval", "float", "na"),
+                new Parameter("maxval", "float", "na"),
+                new Parameter("step", "float", "0.1"),
+                new Parameter("tooltip", "string", "\"\""),
+                new Parameter("inline", "string", "\"\""),
+                new Parameter("group", "string", "\"\""),
+                new Parameter("confirm", "bool", "false")
+        ));
+
+        SIGNATURES.put("input.bool", new PineScriptFunctionSignature("input.bool",
+                new Parameter("defval", "bool"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("tooltip", "string", "\"\""),
+                new Parameter("inline", "string", "\"\""),
+                new Parameter("group", "string", "\"\""),
+                new Parameter("confirm", "bool", "false")
+        ));
+
+        SIGNATURES.put("input.string", new PineScriptFunctionSignature("input.string",
+                new Parameter("defval", "string"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("options", "string[]", "na"),
+                new Parameter("tooltip", "string", "\"\""),
+                new Parameter("inline", "string", "\"\""),
+                new Parameter("group", "string", "\"\""),
+                new Parameter("confirm", "bool", "false")
+        ));
+
+        SIGNATURES.put("input.color", new PineScriptFunctionSignature("input.color",
+                new Parameter("defval", "color"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("tooltip", "string", "\"\""),
+                new Parameter("inline", "string", "\"\""),
+                new Parameter("group", "string", "\"\""),
+                new Parameter("confirm", "bool", "false")
+        ));
+
+        SIGNATURES.put("input.source", new PineScriptFunctionSignature("input.source",
+                new Parameter("defval", "series"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("tooltip", "string", "\"\""),
+                new Parameter("inline", "string", "\"\""),
+                new Parameter("group", "string", "\"\"")
+        ));
+
+        // Math functions
+        SIGNATURES.put("math.abs", new PineScriptFunctionSignature("math.abs",
+                new Parameter("x", "number")
+        ));
+
+        SIGNATURES.put("math.max", new PineScriptFunctionSignature("math.max",
+                new Parameter("x", "number"),
+                new Parameter("y", "number")
+        ));
+
+        SIGNATURES.put("math.min", new PineScriptFunctionSignature("math.min",
+                new Parameter("x", "number"),
+                new Parameter("y", "number")
+        ));
+
+        SIGNATURES.put("math.round", new PineScriptFunctionSignature("math.round",
+                new Parameter("x", "number"),
+                new Parameter("precision", "int", "0")
+        ));
+
+        SIGNATURES.put("math.pow", new PineScriptFunctionSignature("math.pow",
+                new Parameter("base", "number"),
+                new Parameter("exponent", "number")
+        ));
+
+        // Alert functions
+        SIGNATURES.put("alert", new PineScriptFunctionSignature("alert",
+                new Parameter("message", "string"),
+                new Parameter("freq", "string", "alert.freq_once_per_bar")
+        ));
+
+        SIGNATURES.put("alertcondition", new PineScriptFunctionSignature("alertcondition",
+                new Parameter("condition", "bool"),
+                new Parameter("title", "string", "\"\""),
+                new Parameter("message", "string", "\"\"")
+        ));
+
+        // Indicator/Strategy declaration
+        SIGNATURES.put("indicator", new PineScriptFunctionSignature("indicator",
+                new Parameter("title", "string"),
+                new Parameter("shorttitle", "string", "\"\""),
+                new Parameter("overlay", "bool", "false"),
+                new Parameter("format", "string", "format.inherit"),
+                new Parameter("precision", "int", "na"),
+                new Parameter("scale", "string", "scale.right"),
+                new Parameter("max_bars_back", "int", "na"),
+                new Parameter("timeframe", "string", "\"\""),
+                new Parameter("timeframe_gaps", "bool", "true"),
+                new Parameter("explicit_plot_zorder", "bool", "false"),
+                new Parameter("max_lines_count", "int", "50"),
+                new Parameter("max_labels_count", "int", "50"),
+                new Parameter("max_boxes_count", "int", "50")
+        ));
+
+        SIGNATURES.put("strategy", new PineScriptFunctionSignature("strategy",
+                new Parameter("title", "string"),
+                new Parameter("shorttitle", "string", "\"\""),
+                new Parameter("overlay", "bool", "false"),
+                new Parameter("format", "string", "format.inherit"),
+                new Parameter("precision", "int", "na"),
+                new Parameter("scale", "string", "scale.right"),
+                new Parameter("pyramiding", "int", "0"),
+                new Parameter("calc_on_order_fills", "bool", "false"),
+                new Parameter("calc_on_every_tick", "bool", "false"),
+                new Parameter("max_bars_back", "int", "na"),
+                new Parameter("backtest_fill_limits_assumption", "int", "0"),
+                new Parameter("default_qty_type", "string", "strategy.fixed"),
+                new Parameter("default_qty_value", "float", "1"),
+                new Parameter("initial_capital", "float", "1000000"),
+                new Parameter("currency", "string", "currency.NONE"),
+                new Parameter("slippage", "int", "0"),
+                new Parameter("commission_type", "string", "strategy.commission.percent"),
+                new Parameter("commission_value", "float", "0"),
+                new Parameter("process_orders_on_close", "bool", "false"),
+                new Parameter("close_entries_rule", "string", "\"\""),
+                new Parameter("margin_long", "float", "0"),
+                new Parameter("margin_short", "float", "0"),
+                new Parameter("explicit_plot_zorder", "bool", "false"),
+                new Parameter("max_lines_count", "int", "50"),
+                new Parameter("max_labels_count", "int", "50"),
+                new Parameter("max_boxes_count", "int", "50"),
+                new Parameter("risk_free_rate", "float", "0")
+        ));
+    }
+
+    public static PineScriptFunctionSignature getSignature(String functionName) {
+        return SIGNATURES.get(functionName);
+    }
+
+    public static boolean hasSignature(String functionName) {
+        return SIGNATURES.containsKey(functionName);
+    }
+}

--- a/src/main/java/io/github/houseofai/pinescript/parameterinfo/PineScriptFunctionSignature.java
+++ b/src/main/java/io/github/houseofai/pinescript/parameterinfo/PineScriptFunctionSignature.java
@@ -1,0 +1,91 @@
+package io.github.houseofai.pinescript.parameterinfo;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Represents a Pine Script function signature with its parameters.
+ */
+public class PineScriptFunctionSignature {
+    private final String functionName;
+    private final List<Parameter> parameters;
+
+    public PineScriptFunctionSignature(String functionName, Parameter... parameters) {
+        this.functionName = functionName;
+        this.parameters = Arrays.asList(parameters);
+    }
+
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    public List<Parameter> getParameters() {
+        return parameters;
+    }
+
+    public String getParameterText(int index) {
+        if (index < 0 || index >= parameters.size()) {
+            return "";
+        }
+        Parameter param = parameters.get(index);
+        return param.toString();
+    }
+
+    public int getParameterCount() {
+        return parameters.size();
+    }
+
+    /**
+     * Represents a single function parameter.
+     */
+    public static class Parameter {
+        private final String name;
+        private final String type;
+        private final String defaultValue;
+        private final boolean optional;
+
+        public Parameter(String name, String type) {
+            this(name, type, null, false);
+        }
+
+        public Parameter(String name, String type, String defaultValue) {
+            this(name, type, defaultValue, true);
+        }
+
+        public Parameter(String name, String type, String defaultValue, boolean optional) {
+            this.name = name;
+            this.type = type;
+            this.defaultValue = defaultValue;
+            this.optional = optional;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getDefaultValue() {
+            return defaultValue;
+        }
+
+        public boolean isOptional() {
+            return optional;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(name);
+            if (type != null && !type.isEmpty()) {
+                sb.append(": ").append(type);
+            }
+            if (defaultValue != null) {
+                sb.append(" = ").append(defaultValue);
+            }
+            return sb.toString();
+        }
+    }
+}

--- a/src/main/java/io/github/houseofai/pinescript/parameterinfo/PineScriptParameterInfoHandler.java
+++ b/src/main/java/io/github/houseofai/pinescript/parameterinfo/PineScriptParameterInfoHandler.java
@@ -1,0 +1,319 @@
+package io.github.houseofai.pinescript.parameterinfo;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.lang.parameterInfo.*;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
+import io.github.houseofai.pinescript.PineScriptLanguage;
+import io.github.houseofai.pinescript.psi.PineScriptTokenTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Provides parameter information hints for Pine Script functions.
+ */
+public class PineScriptParameterInfoHandler implements ParameterInfoHandler<PsiElement, PineScriptFunctionSignature> {
+
+    @Override
+    public @Nullable PsiElement findElementForParameterInfo(@NotNull CreateParameterInfoContext context) {
+        PsiFile file = context.getFile();
+        if (!isPineScriptFile(file)) {
+            return null;
+        }
+
+        int offset = context.getOffset();
+        PsiElement element = file.findElementAt(offset);
+        if (element == null) {
+            return null;
+        }
+
+        // Find the function call context
+        FunctionCallContext callContext = findFunctionCall(element);
+        if (callContext == null) {
+            return null;
+        }
+
+        // Get the function signature
+        PineScriptFunctionSignature signature = PineScriptFunctionRepository.getSignature(callContext.functionName);
+        if (signature != null) {
+            context.setItemsToShow(new Object[]{signature});
+            return callContext.anchor;
+        }
+
+        return null;
+    }
+
+    @Override
+    public void showParameterInfo(@NotNull PsiElement element, @NotNull CreateParameterInfoContext context) {
+        context.showHint(element, element.getTextRange().getStartOffset(), this);
+    }
+
+    @Override
+    public @Nullable PsiElement findElementForUpdatingParameterInfo(@NotNull UpdateParameterInfoContext context) {
+        PsiFile file = context.getFile();
+        if (!isPineScriptFile(file)) {
+            return null;
+        }
+
+        int offset = context.getOffset();
+        PsiElement element = file.findElementAt(offset);
+        if (element == null) {
+            return null;
+        }
+
+        FunctionCallContext callContext = findFunctionCall(element);
+        return callContext != null ? callContext.anchor : null;
+    }
+
+    @Override
+    public void updateParameterInfo(@NotNull PsiElement place, @NotNull UpdateParameterInfoContext context) {
+        // Find the current parameter index
+        int parameterIndex = getCurrentParameterIndex(place, context.getOffset());
+        context.setCurrentParameter(parameterIndex);
+    }
+
+    @Override
+    public void updateUI(@Nullable PineScriptFunctionSignature signature, @NotNull ParameterInfoUIContext context) {
+        if (signature == null) {
+            context.setUIComponentEnabled(false);
+            return;
+        }
+
+        // Build the parameter list text
+        StringBuilder text = new StringBuilder();
+        int currentIndex = context.getCurrentParameterIndex();
+        int highlightStart = -1;
+        int highlightEnd = -1;
+
+        for (int i = 0; i < signature.getParameterCount(); i++) {
+            if (i > 0) {
+                text.append(", ");
+            }
+
+            int paramStart = text.length();
+            String paramText = signature.getParameterText(i);
+            text.append(paramText);
+            int paramEnd = text.length();
+
+            // Highlight the current parameter
+            if (i == currentIndex) {
+                highlightStart = paramStart;
+                highlightEnd = paramEnd;
+            }
+        }
+
+        context.setupUIComponentPresentation(
+                text.toString(),
+                highlightStart,
+                highlightEnd,
+                !context.isUIComponentEnabled(),
+                false,
+                false,
+                context.getDefaultParameterColor()
+        );
+    }
+
+    /**
+     * Finds the function call context for the given element.
+     */
+    private FunctionCallContext findFunctionCall(PsiElement element) {
+        if (element == null) {
+            return null;
+        }
+
+        // Navigate backwards to find the opening parenthesis
+        PsiElement current = element;
+        int parenDepth = 0;
+        PsiElement openParen = null;
+
+        // First, check if we're inside parentheses
+        while (current != null) {
+            IElementType type = current.getNode() != null ? current.getNode().getElementType() : null;
+
+            if (type == PineScriptTokenTypes.RPAREN) {
+                parenDepth++;
+            } else if (type == PineScriptTokenTypes.LPAREN) {
+                if (parenDepth == 0) {
+                    openParen = current;
+                    break;
+                }
+                parenDepth--;
+            }
+
+            current = current.getPrevSibling();
+            if (current == null) {
+                current = element.getParent();
+                if (current != null) {
+                    current = current.getPrevSibling();
+                }
+            }
+        }
+
+        if (openParen == null) {
+            return null;
+        }
+
+        // Find the function name (identifier before the opening paren)
+        PsiElement functionNameElement = openParen.getPrevSibling();
+        while (functionNameElement != null && isWhitespace(functionNameElement)) {
+            functionNameElement = functionNameElement.getPrevSibling();
+        }
+
+        if (functionNameElement == null) {
+            return null;
+        }
+
+        String functionName = extractFunctionName(functionNameElement);
+        if (functionName == null || functionName.isEmpty()) {
+            return null;
+        }
+
+        return new FunctionCallContext(functionName, openParen);
+    }
+
+    /**
+     * Extracts the function name from a PSI element.
+     */
+    private String extractFunctionName(PsiElement element) {
+        if (element == null) {
+            return null;
+        }
+
+        IElementType type = element.getNode() != null ? element.getNode().getElementType() : null;
+
+        if (type == PineScriptTokenTypes.IDENTIFIER || type == PineScriptTokenTypes.BUILTIN_FUNCTION) {
+            return element.getText();
+        }
+
+        // Try to get the full identifier including dots (e.g., "ta.sma")
+        StringBuilder name = new StringBuilder();
+        PsiElement current = element;
+
+        while (current != null) {
+            IElementType currentType = current.getNode() != null ? current.getNode().getElementType() : null;
+
+            if (currentType == PineScriptTokenTypes.IDENTIFIER ||
+                currentType == PineScriptTokenTypes.BUILTIN_FUNCTION ||
+                currentType == PineScriptTokenTypes.DOT) {
+                name.insert(0, current.getText());
+                current = current.getPrevSibling();
+
+                // Skip whitespace
+                while (current != null && isWhitespace(current)) {
+                    current = current.getPrevSibling();
+                }
+            } else {
+                break;
+            }
+        }
+
+        return name.length() > 0 ? name.toString() : element.getText();
+    }
+
+    /**
+     * Gets the current parameter index based on cursor position.
+     */
+    private int getCurrentParameterIndex(PsiElement element, int offset) {
+        if (element == null) {
+            return 0;
+        }
+
+        // Find the opening parenthesis
+        PsiElement current = element;
+        int parenDepth = 0;
+        PsiElement openParen = null;
+
+        while (current != null) {
+            IElementType type = current.getNode() != null ? current.getNode().getElementType() : null;
+
+            if (type == PineScriptTokenTypes.RPAREN) {
+                parenDepth++;
+            } else if (type == PineScriptTokenTypes.LPAREN) {
+                if (parenDepth == 0) {
+                    openParen = current;
+                    break;
+                }
+                parenDepth--;
+            }
+
+            current = current.getPrevSibling();
+            if (current == null && element.getParent() != null) {
+                current = element.getParent().getPrevSibling();
+            }
+        }
+
+        if (openParen == null) {
+            return 0;
+        }
+
+        // Count commas between opening paren and cursor position
+        int commaCount = 0;
+        current = openParen.getNextSibling();
+        int currentParenDepth = 0;
+
+        while (current != null && current.getTextRange().getStartOffset() < offset) {
+            IElementType type = current.getNode() != null ? current.getNode().getElementType() : null;
+
+            if (type == PineScriptTokenTypes.LPAREN) {
+                currentParenDepth++;
+            } else if (type == PineScriptTokenTypes.RPAREN) {
+                if (currentParenDepth == 0) {
+                    break;
+                }
+                currentParenDepth--;
+            } else if (type == PineScriptTokenTypes.COMMA && currentParenDepth == 0) {
+                commaCount++;
+            }
+
+            current = current.getNextSibling();
+            if (current == null && openParen.getParent() != null) {
+                PsiElement parent = openParen.getParent();
+                current = getNextSiblingInTree(parent, offset);
+            }
+        }
+
+        return commaCount;
+    }
+
+    /**
+     * Helper to get next sibling in tree.
+     */
+    private PsiElement getNextSiblingInTree(PsiElement element, int maxOffset) {
+        PsiElement current = element;
+        while (current != null) {
+            PsiElement next = current.getNextSibling();
+            if (next != null && next.getTextRange().getStartOffset() < maxOffset) {
+                return next;
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+
+    private boolean isWhitespace(PsiElement element) {
+        if (element == null) {
+            return false;
+        }
+        IElementType type = element.getNode() != null ? element.getNode().getElementType() : null;
+        return type == PineScriptTokenTypes.WHITE_SPACE;
+    }
+
+    private boolean isPineScriptFile(PsiFile file) {
+        return file != null && file.getLanguage() == PineScriptLanguage.INSTANCE;
+    }
+
+    /**
+     * Context for a function call.
+     */
+    private static class FunctionCallContext {
+        final String functionName;
+        final PsiElement anchor;
+
+        FunctionCallContext(String functionName, PsiElement anchor) {
+            this.functionName = functionName;
+            this.anchor = anchor;
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -78,6 +78,10 @@
         <!-- Spell checking strategy - disable for PineScript -->
         <spellchecker.support language="PineScript"
                              implementationClass="io.github.houseofai.pinescript.PineScriptSpellcheckingStrategy"/>
+
+        <!-- Parameter info handler -->
+        <codeInsight.parameterInfo language="PineScript"
+                                  implementationClass="io.github.houseofai.pinescript.parameterinfo.PineScriptParameterInfoHandler"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Implements parameter information provider that shows function parameter suggestions when typing inside function parentheses.

Features:
- Parameter hints for common Pine Script functions (plot, ta.*, strategy.*, input.*, math.*, etc.)
- Highlights current parameter based on cursor position
- Shows parameter names, types, and default values
- Supports both built-in and namespaced functions

When users type inside parentheses like plot(close, ), the IDE now shows available parameters: title, color, linewidth, style, etc.